### PR TITLE
Run js functions into the worker

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,8 @@
     "ACTIONS"    : false,
     "WebAssembly": false,
     "getImportObject": false,
-    "moduleInstance"   : false
+    "moduleInstance"   : false,
+    "importObject": false,
+    "wasmModule" : false
   }
 }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ type JsCallback = (context: {
   instance: WebAssembly.Instance,
   importObject: importObject,
   params: any,
-}) => Promise<any>;
+}) => any;
 
 type WasmWorkerModule = {
   exports: {
@@ -78,7 +78,7 @@ type WasmWorkerModule = {
   // run a js function inside the worker and provides it the given params
   // ⚠️ Caveat: the function you pass cannot rely on its surrounding scope, since it is executed in an isolated context.
   // Please use the "params" parameter to provide some values to the callback
-  run: (callback: JsCallback, params: any) => Promise<any>
+  run: (callback: JsCallback, params?: any) => Promise<any>
 };
 
 type Options = {

--- a/README.md
+++ b/README.md
@@ -40,17 +40,45 @@ wasmWorker('add.wasm')
     // ex is a string that represents the exception
     console.error(ex);
   });
+
+// you can also run js functions inside the worker
+// to access importObject for example
+wasmWorker('add.wasm')
+  .then(module => {
+    return module.run(({
+      // module,
+      // importObject,
+      instance,
+      params
+    }) => {
+      // here is sync
+      const sum = instance.exports.add(...params);
+      return '1 + 2 = ' + sum;
+    }, [1, 2]);
+  })
+  .then(result => {
+    console.log(result);
+  });
 ```
 
 ## API
 
-By default wasm-worker exports a single function:
-
 ```js
+type JsCallback = (context: {
+  module: WebAssembly.Module,
+  instance: WebAssembly.Instance,
+  importObject: importObject,
+  params: any,
+}) => Promise<any>;
+
 type WasmWorkerModule = {
   exports: {
     [export: string]: (...any: Array<any>) => Promise<any>
-  }
+  },
+  // run a js function inside the worker and provides it the given params
+  // ⚠️ Caveat: the function you pass cannot rely on its surrounding scope, since it is executed in an isolated context.
+  // Please use the "params" parameter to provide some values to the callback
+  run: (callback: JsCallback, params: any) => Promise<any>
 };
 
 type Options = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-worker",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Move a WebAssembly module into its own thread",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,7 @@
 const ACTIONS = {
   COMPILE_MODULE: 0,
   CALL_FUNCTION_EXPORT: 1,
+  RUN_FUNCTION: 2,
 };
 
 export default ACTIONS;

--- a/src/worker.js
+++ b/src/worker.js
@@ -19,6 +19,7 @@ export default function worker(e) {
       .then(() => {
         let res;
         if (getImportObject !== undefined) {
+          // eslint-disable-next-line
           importObject = getImportObject();
         }
 
@@ -41,6 +42,7 @@ export default function worker(e) {
       .then(({ module, instance }) => {
         // eslint-disable-next-line
         moduleInstance = instance;
+        // eslint-disable-next-line
         wasmModule = module;
         onSuccess({
           exports: WebAssembly.Module
@@ -65,12 +67,13 @@ export default function worker(e) {
 
     Promise.resolve()
       .then(() => {
-        const fun = new Function("return " + func)();
+        // eslint-disable-next-line
+        const fun = new Function(`return ${func}`)();
         onSuccess(fun({
           module: wasmModule,
           instance: moduleInstance,
           importObject,
-          params
+          params,
         }));
       })
       .catch(onError);

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -13,6 +13,10 @@ describe('actions', () => {
     expect(typeof ACTIONS.CALL_FUNCTION_EXPORT).toEqual('number');
   });
 
+  it('should export a run function action', () => {
+    expect(typeof ACTIONS.RUN_FUNCTION).toEqual('number');
+  });
+
   it('should not export duplicated values', () => {
     const values = Object.keys(ACTIONS).map(key => ACTIONS[key]);
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -101,17 +101,17 @@ describe('wasm-worker', () => {
           module,
           instance,
           importObject,
-          params
+          params,
         }) => {
           const err = new Error();
           if (params !== undefined) throw err;
-          if (!module instanceof WebAssembly.Module) throw err;
-          if (!instance instanceof WebAssembly.Instance) throw err;
+          if (!(module instanceof WebAssembly.Module)) throw err;
+          if (!(instance instanceof WebAssembly.Instance)) throw err;
           if (importObject.imports === undefined) throw err;
 
           const sum = instance.exports.add(1, 2);
-          return '1 + 2 = ' + sum;
-        })
+          return `1 + 2 = ${sum}`;
+        }),
       )
       .then((result) => {
         expect(result).toEqual('1 + 2 = 3');
@@ -130,17 +130,17 @@ describe('wasm-worker', () => {
           module,
           instance,
           importObject,
-          params
+          params,
         }) => {
           const err = new Error();
           if (params === undefined) throw err;
-          if (!module instanceof WebAssembly.Module) throw err;
-          if (!instance instanceof WebAssembly.Instance) throw err;
+          if (!(module instanceof WebAssembly.Module)) throw err;
+          if (!(instance instanceof WebAssembly.Instance)) throw err;
           if (importObject.imports === undefined) throw err;
 
           const sum = instance.exports.add(params[0], params[1]);
-          return '1 + 2 = ' + sum;
-        }, [1, 2])
+          return `1 + 2 = ${sum}`;
+        }, [1, 2]),
       )
       .then((result) => {
         expect(result).toEqual('1 + 2 = 3');

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -89,4 +89,62 @@ describe('wasm-worker', () => {
         done();
       });
   });
+
+  it('should run a function inside worker', (done) => {
+    wasmWorker(bytes, {
+      getImportObject: () => ({
+        imports: {},
+      }),
+    })
+      .then(wasmModule =>
+        wasmModule.run(({
+          module,
+          instance,
+          importObject,
+          params
+        }) => {
+          const err = new Error();
+          if (params !== undefined) throw err;
+          if (!module instanceof WebAssembly.Module) throw err;
+          if (!instance instanceof WebAssembly.Instance) throw err;
+          if (importObject.imports === undefined) throw err;
+
+          const sum = instance.exports.add(1, 2);
+          return '1 + 2 = ' + sum;
+        })
+      )
+      .then((result) => {
+        expect(result).toEqual('1 + 2 = 3');
+        done();
+      });
+  });
+
+  it('should run a function inside worker with params', (done) => {
+    wasmWorker(bytes, {
+      getImportObject: () => ({
+        imports: {},
+      }),
+    })
+      .then(wasmModule =>
+        wasmModule.run(({
+          module,
+          instance,
+          importObject,
+          params
+        }) => {
+          const err = new Error();
+          if (params === undefined) throw err;
+          if (!module instanceof WebAssembly.Module) throw err;
+          if (!instance instanceof WebAssembly.Instance) throw err;
+          if (importObject.imports === undefined) throw err;
+
+          const sum = instance.exports.add(params[0], params[1]);
+          return '1 + 2 = ' + sum;
+        }, [1, 2])
+      )
+      .then((result) => {
+        expect(result).toEqual('1 + 2 = 3');
+        done();
+      });
+  });
 });

--- a/test/worker.spec.js
+++ b/test/worker.spec.js
@@ -26,14 +26,10 @@ describe('worker', () => {
 
     /* eslint-disable */
     const ACTIONS = ACTIONZ;
+    let importObject = undefined;
+    let wasmModule = null;
     let moduleInstance = null;
     const getImportObject = undefined;
-    const importObject = {
-      memoryBase: 0,
-      tableBase: 0,
-      memory: new WebAssembly.Memory({ initial: 256 }),
-      table: new WebAssembly.Table({ initial: 0, element: 'anyfunc' }),
-    };
 
     // helper variables
     const id = 0;
@@ -89,14 +85,10 @@ describe('worker', () => {
 
     /* eslint-disable */
     const ACTIONS = ACTIONZ;
+    let importObject = undefined;
+    let wasmModule = null;
     let moduleInstance = null;
     const getImportObject = undefined;
-    const importObject = {
-      memoryBase: 0,
-      tableBase: 0,
-      memory: new WebAssembly.Memory({ initial: 256 }),
-      table: new WebAssembly.Table({ initial: 0, element: 'anyfunc' }),
-    };
 
     // helper variables
     const id = 0;


### PR DESCRIPTION
Sometimes it might be useful to access wasm memory and execute some operations, for example read strings and so on.
This PR adds a new API to execute a js function into the isolated context of the worker and return a Promise to the main thread.