### PR TITLE
Suggest a better worker node.js impl in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > Move a WebAssembly module into its own thread
 
 
-_wasm-worker only supports browser environments, since it uses [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers). For use in a NodeJS environment, Web Workers must be polyfilled using a library like [node-webworker](https://github.com/pgriess/node-webworker)._
+_wasm-worker only supports browser environments, since it uses [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers). For use in a NodeJS environment, Web Workers must be polyfilled using a library like [node-webworker-threads](https://github.com/audreyt/node-webworker-threads)._
 
 ## Installation
 


### PR DESCRIPTION
- [x] Pull request has tests / docs demo, and is linted.
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

Since [node-webworker](https://github.com/pgriess/node-webworker) is [dead](https://github.com/pgriess/node-webworker/issues/43) since 2011, I think it'd be more fair to suggest a newer, maintained worker threads implementation for Node.js, such as https://github.com/audreyt/node-webworker-threads in readme